### PR TITLE
New GCP Rules - Cloudsploit - Part 2 (all rules with DOCs on Zanshin)

### DIFF
--- a/collectors/google/collector.js
+++ b/collectors/google/collector.js
@@ -95,6 +95,14 @@ var calls = {
                 paginationKey: 'pageSize'
             }
         },
+        bigtable: {
+            list: {
+                url: 'https://bigtableadmin.googleapis.com/v2/projects/{projectId}/instances',
+                location: null,
+                pagination: true,
+                paginationKey: 'pageToken'
+           }
+        },
         manyApi: true,
     },
     instanceTemplates: {
@@ -196,11 +204,21 @@ var calls = {
         }
     },
     clusters: {
-        list: {
-            url: 'https://container.googleapis.com/v1/projects/{projectId}/locations/-/clusters',
-            location: null,
-            pagination: false
-        }
+        kubernetes: {
+            list: {
+                url: 'https://container.googleapis.com/v1/projects/{projectId}/locations/-/clusters',
+                location: null,
+                pagination: false
+            }
+        },
+        dataproc: {
+            list: { //https://dataproc.googleapis.com/v1/projects/{projectId}/clusters:list
+                url: 'https://dataproc.googleapis.com/v1/projects/{projectId}/regions/{locationId}/clusters',
+                location: 'region',
+                pagination: true
+            }
+        },
+        manyApi: true,
     },
     managedZones: {
         list: {
@@ -369,17 +387,6 @@ var postcalls = {
             reliesOnSubService: ['sql'],
             reliesOnCall: ['list'],
             properties: ['name'],
-            pagination: true
-        }
-    },
-    datasets: {
-        get: {
-            url: 'https://bigquery.googleapis.com/bigquery/v2/projects/{projectId}/datasets/{datasetId}',
-            location: null,
-            reliesOnService: ['datasets'],
-            reliesOnCall: ['list'],
-            properties: ['datasetId'],
-            subObj: ['datasetReference'],
             pagination: true
         }
     },

--- a/exports.js
+++ b/exports.js
@@ -933,6 +933,10 @@ module.exports = {
         'enableUsageExport'             : require(__dirname + '/plugins/google/compute/enableUsageExport.js'),
         'instanceGroupAutoHealing'      : require(__dirname + '/plugins/google/compute/instanceGroupAutoHealing.js'),
         'publicDiskImages'              : require(__dirname + '/plugins/google/compute/publicDiskImages.js'),
+        'diskLabelsAdded'               : require(__dirname + '/plugins/google/compute/diskLabelsAdded.js'),
+        'imageLabelsAdded'              : require(__dirname + '/plugins/google/compute/imageLabelsAdded.js'),
+        'instanceLabelsAdded'           : require(__dirname + '/plugins/google/compute/instanceLabelsAdded.js'),
+        'snapshotLabelsAdded'           : require(__dirname + '/plugins/google/compute/snapshotLabelsAdded.js'),
 
         'keyRotation'                   : require(__dirname + '/plugins/google/cryptographickeys/keyRotation.js'),
         'keyProtectionLevel'            : require(__dirname + '/plugins/google/cryptographickeys/keyProtectionLevel.js'),
@@ -970,6 +974,7 @@ module.exports = {
         'bucketUniformAccess'           : require(__dirname + '/plugins/google/storage/bucketUniformAccess.js'),
         'bucketLifecycleConfigured'     : require(__dirname + '/plugins/google/storage/bucketLifecycleConfigured.js'),
         'bucketEncryption'              : require(__dirname + '/plugins/google/storage/bucketEncryption.js'),
+        'bucketLabelsAdded'             : require(__dirname + '/plugins/google/storage/bucketLabelsAdded.js'),
 
         'clbHttpsOnly'                  : require(__dirname + '/plugins/google/clb/clbHttpsOnly.js'),
         'clbNoInstances'                : require(__dirname + '/plugins/google/clb/clbNoInstances.js'),
@@ -984,7 +989,6 @@ module.exports = {
         'serviceAccountKeyRotation'     : require(__dirname + '/plugins/google/iam/serviceAccountKeyRotation.js'),
         'serviceAccountManagedKeys'     : require(__dirname + '/plugins/google/iam/serviceAccountManagedKeys.js'),
         'corporateEmailsOnly'           : require(__dirname + '/plugins/google/iam/corporateEmailsOnly.js'),
-
         'serviceAccountTokenCreator'    : require(__dirname + '/plugins/google/iam/serviceAccountTokenCreator.js'),
         'memberAdmin'                   : require(__dirname + '/plugins/google/iam/memberAdmin.js'),
       
@@ -1014,6 +1018,7 @@ module.exports = {
 
         'dnsSecEnabled'                 : require(__dirname + '/plugins/google/dns/dnsSecEnabled.js'),
         'dnsSecSigningAlgorithm'        : require(__dirname + '/plugins/google/dns/dnsSecSigningAlgorithm.js'),
+        'dnsZoneLabelsAdded'            : require(__dirname + '/plugins/google/dns/dnsZoneLabelsAdded.js'),
 
         'auditLoggingEnabled'           : require(__dirname + '/plugins/google/logging/auditLoggingEnabled.js'),
         'projectOwnershipLogging'       : require(__dirname + '/plugins/google/logging/projectOwnershipLogging.js'),
@@ -1028,12 +1033,18 @@ module.exports = {
 
         'datasetAllUsersPolicy'         : require(__dirname + '/plugins/google/bigquery/datasetAllUsersPolicy.js'),
         'tablesCMKEncrypted'            : require(__dirname + '/plugins/google/bigquery/tablesCMKEncrypted.js'),
-      
+        'datasetLabelsAdded'            : require(__dirname + '/plugins/google/bigquery/datasetLabelsAdded.js'),
+
         'topicEncryption'               : require(__dirname + '/plugins/google/pubsub/topicEncryption.js'),
         'deadLetteringEnabled'          : require(__dirname + '/plugins/google/pubsub/deadLetteringEnabled.js'),
+        'topicLabelsAdded'              : require(__dirname + '/plugins/google/pubsub/topicLabelsAdded.js'),
 
         'dataflowHangedJobs'            : require(__dirname + '/plugins/google/dataflow/dataflowHangedJobs.js'),
         'dataflowJobsEncryption'        : require(__dirname + '/plugins/google/dataflow/dataflowJobsEncryption.js'),
+
+        'dataprocClusterEncryption'     : require(__dirname + '/plugins/google/dataproc/dataprocClusterEncryption.js'),
+        'dataprocClusterLabelsAdded'    : require(__dirname + '/plugins/google/dataproc/dataprocClusterLabelsAdded.js'),
+        'hadoopSecureModeEnabled'       : require(__dirname + '/plugins/google/dataproc/hadoopSecureModeEnabled.js'),
 
         'deleteExpiredDeployments'      : require(__dirname + '/plugins/google/deploymentmanager/deleteExpiredDeployments.js'),
 
@@ -1041,9 +1052,12 @@ module.exports = {
 
         'httpTriggerRequireHttps'       : require(__dirname + '/plugins/google/cloudfunctions/httpTriggerRequireHttps.js'),
         'ingressAllTrafficDisabled'     : require(__dirname + '/plugins/google/cloudfunctions/ingressAllTrafficDisabled.js'),
+        'cloudFunctionLabelsAdded'      : require(__dirname + '/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js'),
 
         'apiKeyApplicationRestriction'  : require(__dirname + '/plugins/google/api/apiKeyApplicationRestriction.js'),
         'apiKeyRotation'                : require(__dirname + '/plugins/google/api/apiKeyRotation.js'),
+
+        'bigtableInstanceLabelsAdded'   : require(__dirname + '/plugins/google/bigtable/bigtableInstanceLabelsAdded.js'),
 
         'computeAllowedExternalIPs'     : require(__dirname + '/plugins/google/cloudresourcemanager/computeAllowedExternalIPs.js'),
         'disableAutomaticIAMGrants'     : require(__dirname + '/plugins/google/cloudresourcemanager/disableAutomaticIAMGrants.js'),

--- a/helpers/google/regions.js
+++ b/helpers/google/regions.js
@@ -81,7 +81,8 @@ module.exports = {
     instances: {
         compute: regions,
         sql: ['global'],
-        spanner: ['global']
+        spanner: ['global'],
+        bigtable: ['global']
     },
     functions: [
         'us-east1', 'us-east4', 'us-west2', 'us-west3', 'us-west4', 'us-central1', 'northamerica-northeast1', 'southamerica-east1',
@@ -98,7 +99,10 @@ module.exports = {
     autoscalers: ['global'],
     subnetworks: regions,
     projects: ['global'],
-    clusters: ['global'],
+    clusters: {
+        kubernetes: ['global'],
+        dataproc: regions
+    },
     managedZones: ['global'],
     metrics: ['global'],
     alertPolicies: ['global'],

--- a/plugins/google/bigquery/datasetAllUsersPolicy.js
+++ b/plugins/google/bigquery/datasetAllUsersPolicy.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Granting permissions to allUsers or allAuthenticatedUsers allows anyone to access the dataset. Such access might not be desirable if sensitive data is being stored in the dataset.',
     link: 'https://cloud.google.com/bigquery/docs/dataset-access-controls',
     recommended_action: 'Ensure that each dataset is configured so that no member is set to allUsers or allAuthenticatedUsers.',
-    apis: ['datasets:list', 'datasets:get', 'projects:get'],
+    apis: ['datasets:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -29,7 +29,7 @@ module.exports = {
 
         async.each(regions.datasets, function(region, rcb){
             let datasetsGet = helpers.addSource(cache, source,
-                ['datasets', 'get', region]);
+                ['datasets', 'list', region]);
 
             if (!datasetsGet) return rcb();
 

--- a/plugins/google/bigquery/datasetAllUsersPolicy.spec.js
+++ b/plugins/google/bigquery/datasetAllUsersPolicy.spec.js
@@ -40,7 +40,7 @@ const datasetGet = [
 const createCache = (err, data) => {
     return {
         datasets: {
-            get: {
+            list: {
                 'global': {
                     err: err,
                     data: data

--- a/plugins/google/bigquery/datasetLabelsAdded.js
+++ b/plugins/google/bigquery/datasetLabelsAdded.js
@@ -1,0 +1,67 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataset Labels Added',
+    category: 'BigQuery',
+    domain: 'Databases',
+    description: 'Ensure that all BigQuery datasets have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/bigquery/docs/adding-labels',
+    recommended_action: 'Ensure labels are added to all BigQuery datasets.',
+    apis: ['datasets:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.datasets, function(region, rcb){
+            let datasets = helpers.addSource(cache, source,
+                ['datasets', 'list', region]);
+
+            if (!datasets) return rcb();
+
+            if (datasets.err || !datasets.data) {
+                helpers.addResult(results, 3, 'Unable to query BigQuery datasets', region, null, null, datasets.err);
+                return rcb();
+            }
+
+            if (!datasets.data.length) {
+                helpers.addResult(results, 0, 'No BigQuery datasets found', region);
+                return rcb();
+            }
+
+            datasets.data.forEach(dataset => {
+                if (!dataset.id) return;
+
+                let resource = helpers.createResourceName('datasets', dataset.id.split(':')[1] || dataset.id, project);
+
+                if (dataset.labels &&
+                    Object.keys(dataset.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(dataset.labels).length} labels found for BigQuery dataset`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'BigQuery dataset does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/bigquery/datasetLabelsAdded.spec.js
+++ b/plugins/google/bigquery/datasetLabelsAdded.spec.js
@@ -1,0 +1,111 @@
+var expect = require('chai').expect;
+var plugin = require('./datasetLabelsAdded');
+
+const datasets = [
+    {
+        kind: 'bigquery#dataset',
+        id: 'testproj:ds1',
+        datasetReference: { datasetId: 'ds1', projectId: 'testproj' },
+        labels: { dataset1: 'label' },
+        location: 'us-central1'
+    },
+    {
+        kind: 'bigquery#dataset',
+        id: 'testproj:ds2',
+        datasetReference: { datasetId: 'ds2', projectId: 'testproj' },
+        labels: {},
+        location: 'us-central1'
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        datasets: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('datasetLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a dataset error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query BigQuery datasets');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no datasets are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No BigQuery datasets found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the dataset', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for BigQuery dataset');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [datasets[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the dataset', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('BigQuery dataset does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [datasets[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/bigquery/tablesCMKEncrypted.js
+++ b/plugins/google/bigquery/tablesCMKEncrypted.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'By default Google encrypts all datasets using Google-managed encryption keys. To have more control over the encryption process of your BigQuery dataset tables you can use Customer-Managed Keys (CMKs).',
     link: 'https://cloud.google.com/bigquery/docs/customer-managed-encryption',
     recommended_action: 'Ensure that each BigQuery dataset table has desired encryption level.',
-    apis: ['datasets:list', 'datasets:get', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['datasets:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         bigquery_tables_encryption_protection_level: {
             name: 'BigQuery Dataset Encryption Protection Level',
@@ -55,7 +55,7 @@ module.exports = {
             function(cb) {
                 async.each(regions.datasets, function(region, rcb) {
                     let datasetsGet = helpers.addSource(cache, source,
-                        ['datasets', 'get', region]);
+                        ['datasets', 'list', region]);
 
                     if (!datasetsGet) return rcb();
 

--- a/plugins/google/bigquery/tablesCMKEncrypted.spec.js
+++ b/plugins/google/bigquery/tablesCMKEncrypted.spec.js
@@ -52,7 +52,7 @@ const datasetGet = [
 const createCache = (err, data, keysErr, keysList) => {
     return {
         datasets: {
-            get: {
+            list: {
                 'global': {
                     err: err,
                     data: data

--- a/plugins/google/bigtable/bigtableInstanceLabelsAdded.js
+++ b/plugins/google/bigtable/bigtableInstanceLabelsAdded.js
@@ -1,0 +1,62 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'BigTable Instance Labels Added',
+    category: 'BigTable',
+    domain: 'Databases',
+    description: 'Ensure that all BigTable instances have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/bigtable/docs/creating-managing-labels',
+    recommended_action: 'Ensure labels are added to all BigTable instances.',
+    apis: ['instances:bigtable:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        async.each(regions.instances.bigtable, function(region, rcb){
+            let instances =  helpers.addSource(
+                cache, source, ['instances', 'bigtable', 'list', region]);
+
+            if (!instances) return rcb();
+
+            if (instances.err || !instances.data) {
+                helpers.addResult(results, 3, 'Unable to query BigTable instances', region, null, null, instances.err);
+                return rcb();
+            }
+
+            if (!instances.data.length) {
+                helpers.addResult(results, 0, 'No BigTable instances found', region);
+                return rcb();
+            }
+
+            instances.data.forEach(instance => {
+
+                if (instance.labels &&
+                    Object.keys(instance.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(instance.labels).length} labels found for BigTable instance`, region, instance.name);
+                } else {
+                    helpers.addResult(results, 2,
+                        'BigTable instance does not have any labels', region, instance.name);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/bigtable/bigtableInstanceLabelsAdded.spec.js
+++ b/plugins/google/bigtable/bigtableInstanceLabelsAdded.spec.js
@@ -1,0 +1,115 @@
+var expect = require('chai').expect;
+var plugin = require('./bigtableInstanceLabelsAdded');
+
+const instances = [
+    {
+        name: 'projects/testproj/instances/test-1',
+        displayName: 'test-1',
+        state: 'READY',
+        type: 'PRODUCTION',
+        labels: { 'label': 'label' },
+        createTime: '2022-10-15T22:02:43.720541615Z'
+    },
+    {
+        name: 'projects/testproj/instances/test-2',
+        displayName: 'test-2',
+        state: 'READY',
+        type: 'PRODUCTION',
+        createTime: '2022-10-15T22:02:43.720541615Z'
+    },
+
+];
+
+const createCache = (err, data) => {
+    return {
+        intances: {
+            bigtable: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('bigtableInstanceLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if an instance error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query BigTable instances');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no bigtable instances are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No BigTable instances found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the instance', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for BigTable instance');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [instances[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the instance', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('BigTable instance does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [instances[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js
+++ b/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.js
@@ -1,0 +1,53 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Cloud Function Labels Added',
+    category: 'Cloud Functions',
+    domain: 'Serverless',
+    description: 'Ensure that all Cloud Functions have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/functions/docs/configuring',
+    recommended_action: 'Ensure labels are added to all Cloud Functions.',
+    apis: ['functions:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+        
+        async.each(regions.functions, (region, rcb) => {
+            var functions = helpers.addSource(cache, source,
+                ['functions', 'list', region]);
+
+            if (!functions) return rcb();
+
+            if (functions.err || !functions.data) {
+                helpers.addResult(results, 3,
+                    'Unable to query for Google Cloud Functions: ' + helpers.addError(functions), region, null, null, functions.err);
+                return rcb();
+            }
+
+            if (!functions.data.length) {
+                helpers.addResult(results, 0, 'No Google Cloud functions found', region);
+                return rcb();
+            }
+
+            functions.data.forEach(func => {
+                if (!func.name) return;
+
+                if (func.labels &&
+                    Object.keys(func.labels).length) {
+                    helpers.addResult(results, 0, `${Object.keys(func.labels).length} labels found for Cloud Function`, region, func.name);
+                } else {
+                    helpers.addResult(results, 2, 'Cloud Function does not have any labels', region, func.name);
+                }
+
+            });
+
+            rcb();
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.spec.js
+++ b/plugins/google/cloudfunctions/cloudFunctionLabelsAdded.spec.js
@@ -1,0 +1,115 @@
+var expect = require('chai').expect;
+var plugin = require('./cloudFunctionLabelsAdded');
+
+
+const functions = [
+    {
+        "name": "projects/my-test-project/locations/us-central1/functions/function-1",
+        "status": "ACTIVE",
+        "entryPoint": "helloWorld",
+        "timeout": "60s",
+        "availableMemoryMb": 256,
+        "updateTime": "2021-09-24T06:18:15.265Z",
+        "runtime": "nodejs14",
+        "ingressSettings": "ALLOW_ALL"
+      },
+      {
+        "name": "projects/my-test-project/locations/us-central1/functions/function-1",
+        "status": "ACTIVE",
+        "entryPoint": "helloWorld",
+        "timeout": "60s",
+        "availableMemoryMb": 256,
+        "updateTime": "2021-09-24T06:18:15.265Z",
+        "versionId": "1",
+        "runtime": "nodejs14",
+        "ingressSettings": "ALLOW_INTERNAL_AND_GCLB",
+        "labels": { 'deployment-tool': 'console-cloud' }
+    
+      }
+];
+
+const createCache = (list, err) => {
+    return {
+        functions: {
+            list: {
+                'us-central1': {
+                    err: err,
+                    data: list
+                }
+            }
+        }
+    }
+};
+
+describe('cloudFunctionLabelsAdded', function () {
+    describe('run', function () {
+        it('should give passing result if no cloud functions found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Google Cloud functions found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give unknown result if unable to query for Google Cloud functions', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query for Google Cloud Functions');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                {message: 'error'},
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if google cloud function has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Cloud Function');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [functions[1]],
+                null
+                );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if google cloud function does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(
+                [functions[0]],
+                null            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});
+

--- a/plugins/google/compute/autoscaleEnabled.js
+++ b/plugins/google/compute/autoscaleEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Enabling autoscale increases efficiency and improves cost management for resources.',
     link: 'https://cloud.google.com/compute/docs/autoscaler/',
     recommended_action: 'Ensure autoscaling is enabled for all instance groups.',
-    apis: ['instanceGroups:aggregatedList', 'autoscalers:aggregatedList','clusters:list', 'projects:get'],
+    apis: ['instanceGroups:aggregatedList', 'autoscalers:aggregatedList','clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -56,7 +56,7 @@ module.exports = {
             return rcb();
         }, function() {
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', ['global']]);
+                ['clusters', 'kubernetes', 'list', ['global']]);
 
             if (clusters.err || !clusters.data) {
                 helpers.addResult(results, 3, 'Unable to query clusters', 'global', null, null, clusters.err);

--- a/plugins/google/compute/autoscaleEnabled.spec.js
+++ b/plugins/google/compute/autoscaleEnabled.spec.js
@@ -21,10 +21,12 @@ const createCache = (instanceData, autoscalers, instanceGroupsError, autoScalers
             }
         },
         clusters: {
-            list: {
-                'global': {
-                    data: clusters,
-                    err: null
+            kubernetes: {
+                list: {
+                    'global': {
+                        data: clusters,
+                        err: null
+                    }
                 }
             }
         },

--- a/plugins/google/compute/diskLabelsAdded.js
+++ b/plugins/google/compute/diskLabelsAdded.js
@@ -1,0 +1,86 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Disk Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all Compute Disks have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all Compute Disks.',
+    apis: ['disks:aggregatedList'],
+    
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let disks = helpers.addSource(cache, source,
+            ['disks', 'aggregatedList', ['global']]);
+
+        if (!disks) return callback(null, results, source);
+
+        if (disks.err || !disks.data) {
+            helpers.addResult(results, 3, 'Unable to query compute disks', 'global', null, null, disks.err);
+            return callback(null, results, source);
+        }
+
+        regions.all_regions.forEach(region => {
+            var noDisks = [];
+            var zones = regions.zones;
+            let disksInRegion = [];
+            let regionData = disks.data[`regions/${region}`];
+
+            if (regionData && regionData['disks'] && regionData['disks'].length) {
+                disksInRegion = disks.data[`regions/${region}`].disks.map(disk => { return {...disk, locationType: 'region', location: region};});
+            }
+        
+            zones[region].forEach(zone => {
+                let disksInZone = [];
+                let zoneData = disks.data[`zones/${zone}`];
+               
+                if (zoneData && zoneData['disks'] && zoneData['disks'].length) {
+                    disksInZone = disks.data[`zones/${zone}`].disks.map(disk => { return {...disk, locationType: 'zone', location: zone};});
+                }
+
+                if (!disksInZone.length) {
+                    noDisks.push(zone);
+                }
+
+                disksInRegion = disksInRegion.concat(disksInZone);
+            });
+
+            disksInRegion.forEach(disk => {
+                if (!disk.id || !disk.creationTimestamp) return;
+
+                let resource = helpers.createResourceName('disks', disk.name, project, disk.locationType, disk.location);
+
+                if (disk.labels &&
+                    Object.keys(disk.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(disk.labels).length} labels found for compute disk`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Compute disk does not have any labels', region, resource);
+                }
+
+            });
+
+            if (noDisks.length) {
+                helpers.addResult(results, 0, `No compute disks found in following zones: ${noDisks.join(', ')}`, region);
+            }
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/compute/diskLabelsAdded.spec.js
+++ b/plugins/google/compute/diskLabelsAdded.spec.js
@@ -1,0 +1,133 @@
+var expect = require('chai').expect;
+var plugin = require('./diskLabelsAdded');
+
+const createCache = (diskData, error) => {
+    return {
+        disks: {
+            aggregatedList: {
+                'global': {
+                    data: diskData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('diskLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown if unable to query compute disks', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query compute disks');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if No compute disks found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No compute disks found');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if disk does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                {
+                    "regions/us-east1": {
+                        "disks": [
+                            {
+                                "id": "1111111",
+                                "creationTimestamp": "2021-09-23T12:58:54.065-07:00",
+                                "name": "disk-1",
+                                "sizeGb": "10",
+                                "status": "READY",
+                                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/disks/disk-1",
+                                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/diskTypes/pd-balanced",
+                                "labelFingerprint": "42WmSpB8rSM=",
+                                "region": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1",
+                                "physicalBlockSizeBytes": "4096",
+                                "kind": "compute#disk",
+                                "resourcePolicies": [
+                                    'https://www.googleapis.com/compute/v1/projects/my-project/regions/us-east1/resourcePolicies/schedule-1'
+                                  ],
+                            }
+                        ]
+                    },
+                }     
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if disk has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for compute disk');
+                expect(results[0].region).to.equal('us-east1');
+                done()
+            };
+
+            const cache = createCache(
+                {
+                    "regions/us-east1": {
+                        "disks": [
+                            {
+                                "id": "1111111",
+                                "creationTimestamp": "2021-09-23T12:58:54.065-07:00",
+                                "name": "disk-1",
+                                "sizeGb": "10",
+                                "status": "READY",
+                                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/disks/disk-1",
+                                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1/diskTypes/pd-balanced",
+                                "labelFingerprint": "42WmSpB8rSM=",
+                                "labels": {"test": "test"},
+                                "region": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/us-east1",
+                                "physicalBlockSizeBytes": "4096",
+                                "kind": "compute#disk"
+                            }
+                        ]
+                    },
+                }     
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+}); 

--- a/plugins/google/compute/imageLabelsAdded.js
+++ b/plugins/google/compute/imageLabelsAdded.js
@@ -1,0 +1,57 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Image Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all VM disk images have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all disk images.',
+    apis: ['images:list'],
+    
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let images = helpers.addSource(cache, source,
+            ['images', 'list', 'global']);
+
+        if (!images || images.err || !images.data) {
+            helpers.addResult(results, 3, 'Unable to query Disk Images: ' + helpers.addError(images), 'global');
+            return callback(null, results, source);
+        }
+
+        if (!images.data.length) {
+            helpers.addResult(results, 0, 'No Disk Images found', 'global');
+            return callback(null, results, source);
+        }
+        
+        images.data.forEach(image => {
+
+            let resource = helpers.createResourceName('images', image.name, project, 'global');
+
+            if (image.labels &&
+                Object.keys(image.labels).length) {
+                helpers.addResult(results, 0,
+                    `${Object.keys(image.labels).length} labels found for disk image`, 'global', resource);
+            } else {
+                helpers.addResult(results, 2,
+                    'Disk image does not have any labels', 'global', resource);
+            }
+
+        });
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/compute/imageLabelsAdded.spec.js
+++ b/plugins/google/compute/imageLabelsAdded.spec.js
@@ -1,0 +1,117 @@
+var expect = require('chai').expect;
+var plugin = require('./imageLabelsAdded');
+
+const images = [
+    {
+        "id": "1231",
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-1",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-1",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-1",
+        "kind": "compute#image"
+    },
+    {
+        "id": 1232,
+        "creationTimestamp": "2022-03-09T16:05:01.878-08:00",
+        "name": "image-2",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/test-proj/zones/us-central1-a/disks/disk-2",
+        "sourceDiskId": "4476293856257965646",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-proj/global/images/image-2",
+        "labels": {"label-1": "test"},
+        "kind": "compute#image"
+    }
+];
+const createCache = (imageData, error) => {
+    return {
+        images: {
+            list: {
+                'global': {
+                    data: imageData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('imageLabelsAdded', function () {
+    describe('run', function () {
+
+        it('should give unknown if unable to query disk images', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Disk Images');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if no disk images found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Disk Images found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if disk image does not have any labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[0]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if labels are added for disk image', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for disk image');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [images[1]],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+    })
+});

--- a/plugins/google/compute/instanceLabelsAdded.js
+++ b/plugins/google/compute/instanceLabelsAdded.js
@@ -1,0 +1,72 @@
+var async   = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Instance Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that all Virtual Machine instances have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all VM instances.',
+    apis: ['instances:compute:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.instances.compute, (region, rcb) => {
+            var zones = regions.zones;
+            var noInstances = [];
+            async.each(zones[region], function(zone, zcb) {
+                var instances = helpers.addSource(cache, source,
+                    ['instances', 'compute', 'list', zone ]);
+
+                if (!instances) return zcb();
+
+                if (instances.err || !instances.data) {
+                    helpers.addResult(results, 3, 'Unable to query instances', region, null, null, instances.err);
+                    return zcb();
+                }
+
+                if (!instances.data.length) {
+                    noInstances.push(zone);
+                    return zcb();
+                }
+
+                instances.data.forEach(instance => {
+                    let resource = helpers.createResourceName('instances', instance.name, project, 'zone', zone);
+
+                    if (instance.labels &&
+                        Object.keys(instance.labels).length) {
+                        helpers.addResult(results, 0,
+                            `${Object.keys(instance.labels).length} labels found for VM instance.`, region, resource);
+                    } else {
+                        helpers.addResult(results, 2,
+                            'VM instance does not have any labels', region, resource);
+                    }
+                });
+                zcb();
+            }, function() {
+                if (noInstances.length) {
+                    helpers.addResult(results, 0, `No instances found in following zones: ${noInstances.join(', ')}`, region);
+                }
+                rcb();
+            });
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/compute/instanceLabelsAdded.spec.js
+++ b/plugins/google/compute/instanceLabelsAdded.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./instanceLabelsAdded');
+
+const createCache = (instanceData, error) => {
+    return {
+        instances:
+            compute: {
+                list: {
+                    'us-central1-a': {
+                        data: instanceData,
+                        err: error
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'testproj'
+                }
+            }
+        }
+    }
+};
+
+describe('instanceLabelsAdded', function () {
+    describe('run', function () {
+
+        it('should give unknown if an instance error occurs', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query instances');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass no VM Instances', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No instances found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if instance does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        "id": "1074579276103575670",
+                        "creationTimestamp": "2019-09-25T14:05:30.014-07:00",
+                        "name": "instance-2",
+                        "description": "",
+                        "tags": {
+                            "fingerprint": "42WmSpB8rSM="
+                        },
+                        "canIpForward": false,
+                        "labelFingerprint": "42WmSpB8rSM=",
+                        "startRestricted": false,
+                        "deletionProtection": false,
+                        "kind": "compute#instance"
+                    }
+                ],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if instance has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for VM instance');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        "id": "1074579276103575670",
+                        "creationTimestamp": "2019-09-25T14:05:30.014-07:00",
+                        "name": "instance-2",
+                        "description": "",
+                        "tags": {
+                            "fingerprint": "42WmSpB8rSM="
+                        },
+                        "canIpForward": false,
+                        "labelFingerprint": "42WmSpB8rSM=",
+                        "startRestricted": false,
+                        "labels": {"test": "test"},
+                        "kind": "compute#instance"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+})

--- a/plugins/google/compute/snapshotLabelsAdded.js
+++ b/plugins/google/compute/snapshotLabelsAdded.js
@@ -1,0 +1,70 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Snapshot Labels Added',
+    category: 'Compute',
+    domain: 'Compute',
+    description: 'Ensure that Compute disk snapshots have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/compute/docs/labeling-resources',
+    recommended_action: 'Ensure labels are added to all Compute disk snapshots.',
+    apis: ['snapshots:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+       
+        var project = projects.data[0].name;
+
+        let snapshots = helpers.addSource(cache, source,
+            ['snapshots', 'list', 'global']);
+
+        if (!snapshots) return callback(null, results, source);
+
+        if (snapshots.err || !snapshots.data) {
+            helpers.addResult(results, 3, 'Unable to query for disk snapshots: ' + helpers.addError(snapshots), 'global');
+            return callback(null, results, source);
+        }
+        if (!snapshots.data.length) {
+            helpers.addResult(results, 0, 'No disk snapshots found', 'global');
+            return callback(null, results, source);
+        }
+
+        var snapshotsFound = false;
+
+        snapshots.data.forEach(snapshot => {
+            if (snapshot.creationTimestamp) {
+
+                snapshotsFound = true;
+                let resource = helpers.createResourceName('snapshot', snapshot.name, project, 'global');
+
+                if (snapshot.labels &&
+                    Object.keys(snapshot.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(snapshot.labels).length} labels found for compute disk snapshot`, 'global', resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Compute disk snapshot does not have any labels', 'global', resource);
+                }
+
+            }
+        });
+
+        if (!snapshotsFound) {
+            helpers.addResult(results, 0, 'No snapshots found in the project', 'global', project);
+        }
+
+        callback(null, results, source);
+
+    }
+};

--- a/plugins/google/compute/snapshotLabelsAdded.spec.js
+++ b/plugins/google/compute/snapshotLabelsAdded.spec.js
@@ -1,0 +1,129 @@
+var expect = require('chai').expect;
+var plugin = require('./snapshotLabelsAdded');
+
+const createCache = (snapshotData, error) => {
+    return {
+        snapshots: {
+            list: {
+                'global': {
+                    data: snapshotData,
+                    err: error
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: 'test-proj'
+                }
+            }
+        }
+    }
+};
+
+describe('snapshotLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown if unable to query compute disk snapshots', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query for disk snapshots');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                ['error']
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should pass if No compute disk snapshots found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No disk snapshots found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should fail if snapshot does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        id: '11111',
+                        creationTimestamp: '2020-09-08T01:48:16.346-07:00',
+                        name: 'snapshot-1',
+                        status: 'READY',
+                        sourceDisk: 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/disks/disk-1',
+                        sourceDiskId: '7633933784896409327',
+                        diskSizeGb: '10',
+                        storageBytes: '0',
+                        storageBytesStatus: 'UP_TO_DATE',
+                        selfLink: 'https://www.googleapis.com/compute/v1/projects/my-project-1/global/snapshots/snapshot-1',
+                        labelFingerprint: '42WmSpB8rSM=',
+                        storageLocations: ['us-central1'],
+                        downloadBytes: '1390',
+                        kind: 'compute#snapshot'
+                    }
+                ],
+                null
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+        it('should pass if snapshot has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for compute disk snapshot');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                [
+                    {
+                        id: '11111',
+                        creationTimestamp: new Date(),
+                        name: 'snapshot-1',
+                        status: 'READY',
+                        sourceDisk: 'https://www.googleapis.com/compute/v1/projects/my-project-1/zones/us-central1-a/disks/disk-1',
+                        sourceDiskId: '7633933784896409327',
+                        diskSizeGb: '10',
+                        storageBytes: '0',
+                        labels: {test: "test"},
+                        storageBytesStatus: 'UP_TO_DATE',
+                        selfLink: 'https://www.googleapis.com/compute/v1/projects/my-project-1/global/snapshots/snapshot-1',
+                        labelFingerprint: '42WmSpB8rSM=',
+                        storageLocations: ['us-central1'],
+                        downloadBytes: '1390',
+                        kind: 'compute#snapshot'
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+
+    })
+});

--- a/plugins/google/dataproc/dataprocClusterEncryption.js
+++ b/plugins/google/dataproc/dataprocClusterEncryption.js
@@ -1,0 +1,111 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataproc Cluster Encryption',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that Dataproc clusters have encryption enabled using desired protection level.',
+    more_info: 'By default, all dataproc clusters are encrypted using Google-managed keys. To have better control over how your dataproc clusters are encrypted, you can use Customer-Managed Keys (CMKs).',
+    link: 'https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/customer-managed-encryption',
+    recommended_action: 'Ensure that all Dataproc clusters have desired encryption level.',
+    apis: ['clusters:dataproc:list', 'keyRings:list', 'cryptoKeys:list'],
+    settings: {
+        dataproc_cluster_encryption_level: {
+            name: 'Dataproc Cluster Encryption Level',
+            description: 'Desired protection level for Dataproc clusters. default: google-managed, cloudcmek: customer managed encryption keys, ' +
+                'cloudhsm: customer managed HSM encryption key, external: imported or externally managed key',
+            regex: '^(default|cloudcmek|cloudhsm|external)$',
+            default: 'cloudcmek'
+        }
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let desiredEncryptionLevelStr = settings.dataproc_cluster_encryption_level || this.settings.dataproc_cluster_encryption_level.default;
+        var desiredEncryptionLevel = helpers.PROTECTION_LEVELS.indexOf(desiredEncryptionLevelStr);
+
+        var keysObj = {};
+
+        let projects = helpers.addSource(cache, source,
+            ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.series([
+            function(cb) {
+                async.each(regions.cryptoKeys, function(region, rcb) {
+                    let cryptoKeys = helpers.addSource(
+                        cache, source, ['cryptoKeys', 'list', region]);
+                    if (cryptoKeys && cryptoKeys.data && cryptoKeys.data.length) helpers.listToObj(keysObj, cryptoKeys.data, 'name');
+                    rcb();
+                }, function() {
+                    cb();
+                });
+            },
+            function(cb) {
+                async.each(regions.clusters.dataproc, function(region, rcb) {
+
+                    let clusters = helpers.addSource(
+                        cache, source, ['clusters', 'dataproc', 'list', region]);
+
+                    if (!clusters) return rcb();
+
+                    if (clusters.err || !clusters.data) {
+                        helpers.addResult(results, 3, 'Unable to query Dataproc clusters: ' + helpers.addError(clusters), region, null, null, clusters.err);
+                        return rcb();
+                    }
+
+                    if (!clusters.data.length) {
+                        helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                        return rcb();
+                    }
+                    
+                    if (clusters && clusters.data) {
+                        clusters.data.forEach(cluster => {
+                            if (!cluster.clusterName) return;
+
+                            let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+                            let currentEncryptionLevel;
+                           
+                            if (cluster && cluster.config && cluster.config.encryptionConfig && cluster.config.encryptionConfig.gcePdKmsKeyName
+                                && keysObj[cluster.config.encryptionConfig.gcePdKmsKeyName]) {
+                                currentEncryptionLevel = helpers.getProtectionLevel(keysObj[cluster.config.encryptionConfig.gcePdKmsKeyName], helpers.PROTECTION_LEVELS);
+                            } else {
+                                currentEncryptionLevel = 1; //default
+                            }
+
+                            let currentEncryptionLevelStr = helpers.PROTECTION_LEVELS[currentEncryptionLevel];
+
+                            if (currentEncryptionLevel >= desiredEncryptionLevel) {
+                                helpers.addResult(results, 0,
+                                    `Dataproc cluster has encryption level ${currentEncryptionLevelStr} which is greater than or equal to ${desiredEncryptionLevelStr}`,
+                                    region, resource);
+                            } else {
+                                helpers.addResult(results, 2,
+                                    `Dataproc cluster has encryption level ${currentEncryptionLevelStr} which is less than ${desiredEncryptionLevelStr}`,
+                                    region, resource);
+                            }
+                        });
+                    }
+                    
+                    rcb();
+                }, function() {
+                    cb();
+                });
+            }
+        ], function() {
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/dataprocClusterEncryption.spec.js
+++ b/plugins/google/dataproc/dataprocClusterEncryption.spec.js
@@ -1,0 +1,155 @@
+var expect = require('chai').expect;
+var plugin = require('./dataprocClusterEncryption');
+
+const cryptoKeys = [
+    {
+        name: "projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-2",
+        primary: {
+            name: "projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-1/cryptoKeyVersions/1",
+            state: "DESTROYED",
+            createTime: "2021-06-17T08:01:36.739860492Z",
+            destroyEventTime: "2021-06-18T11:17:00.798768Z",
+            protectionLevel: "SOFTWARE",
+            algorithm: "GOOGLE_SYMMETRIC_ENCRYPTION",
+            generateTime: "2021-06-17T08:01:36.739860492Z",
+        },
+        purpose: "ENCRYPT_DECRYPT",
+        createTime: "2021-06-17T08:01:36.739860492Z",
+        nextRotationTime: "2021-09-14T19:00:00Z",
+        rotationPeriod: "7776000s",
+        versionTemplate: {
+            protectionLevel: "SOFTWARE",
+            algorithm: "GOOGLE_SYMMETRIC_ENCRYPTION",
+        },
+    }
+];
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        config: {
+            encryptionConfig: {
+                gcePdKmsKeyName: 'projects/test-dev/locations/global/keyRings/test-kr/cryptoKeys/test-key-2'
+            }
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        config: {
+            securityConfig: { kerberosConfig: {} },
+            endpointConfig: {}
+        },
+        labels: {}
+    },
+];
+
+const createCache = (err, data, keysList, keysErr) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        cryptoKeys: {
+            list: {
+                'global': {
+                    err: keysErr,
+                    data: keysList
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dataprocClusterEncryption', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if no dataproc clusters found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [],
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if cluster has desired encryption level', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('which is greater than or equal to');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [clusters[0]],
+                cryptoKeys,
+                null
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if cluster does not have desired encryption level', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('which is less than');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [clusters[1]],
+                cryptoKeys,
+                null
+            );
+            plugin.run(cache, {}, callback);
+        });
+    })
+});

--- a/plugins/google/dataproc/dataprocClusterLabelsAdded.js
+++ b/plugins/google/dataproc/dataprocClusterLabelsAdded.js
@@ -1,0 +1,67 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Dataproc Cluster Labels Added',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that all Dataproc clusters have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/dataproc/docs/guides/creating-managing-labels',
+    recommended_action: 'Ensure labels are added to all Dataproc clusters.',
+    apis: ['dataproc:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.clusters.dataproc, function(region, rcb){
+            let clusters = helpers.addSource(cache, source,
+                ['clusters', 'dataproc' ,'list', region]);
+
+            if (!clusters) return rcb();
+
+            if (clusters.err || !clusters.data) {
+                helpers.addResult(results, 3, 'Unable to query Dataproc clusters', region, null, null, clusters.err);
+                return rcb();
+            }
+
+            if (!clusters.data.length) {
+                helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                return rcb();
+            }
+
+            clusters.data.forEach(cluster => {
+                if (!cluster.clusterName) return;
+
+                let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+
+                if (cluster.labels &&
+                    Object.keys(cluster.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(cluster.labels).length} labels found for Dataproc cluster`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Dataproc cluster does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/dataprocClusterLabelsAdded.spec.js
+++ b/plugins/google/dataproc/dataprocClusterLabelsAdded.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./dataprocClusterLabelsAdded');
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        labels: {
+            'goog-dataproc-cluster-name': 'cluster-bd18',
+            'goog-dataproc-cluster-uuid': '090e0094-dfb8-4d21-944c-d452452e528f',
+            'goog-dataproc-location': 'us-central1'
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        labels: {}
+    },
+];
+
+const createCache = (err, data) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dataprocClusterLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no clusters are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Dataproc cluster');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Dataproc cluster does not have any labels');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/dataproc/hadoopSecureModeEnabled.js
+++ b/plugins/google/dataproc/hadoopSecureModeEnabled.js
@@ -1,0 +1,68 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Hadoop Secure Mode Enabled',
+    category: 'Dataproc',
+    domain: 'Compute',
+    description: 'Ensure that all Dataproc clusters have hadoop secure mode enabled.',
+    more_info: 'Enabling Hadoop secure mode will allow multi-tenancy with security features like isolation, encryption, and user authentication within the cluster. It also enforces all Hadoop services and users to be authenticated via Kerberos Key distribution.',
+    link: 'https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/security',
+    recommended_action: 'Enable Hadoop secure mode for all Dataproc clusters.',
+    apis: ['clusters:dataproc:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.clusters.dataproc, function(region, rcb){
+            let clusters = helpers.addSource(cache, source,
+                ['clusters', 'dataproc' ,'list', region]);
+
+            if (!clusters) return rcb();
+
+            if (clusters.err || !clusters.data) {
+                helpers.addResult(results, 3, 'Unable to query Dataproc clusters', region, null, null, clusters.err);
+                return rcb();
+            }
+
+            if (!clusters.data.length) {
+                helpers.addResult(results, 0, 'No Dataproc clusters found', region);
+                return rcb();
+            }
+
+            clusters.data.forEach(cluster => {
+
+                if (!cluster.clusterName) return;
+
+                let resource = helpers.createResourceName('clusters', cluster.clusterName, project, 'region', region);
+
+                if (cluster.config && cluster.config.securityConfig
+                        && cluster.config.securityConfig.kerberosConfig && cluster.config.securityConfig.kerberosConfig.enableKerberos) {
+                    helpers.addResult(results, 0,
+                        'Hadoop Secure mode is enabled for Dataproc cluster', region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Hadoop Secure mode is not enabled for Dataproc cluster', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dataproc/hadoopSecureModeEnabled.spec.js
+++ b/plugins/google/dataproc/hadoopSecureModeEnabled.spec.js
@@ -1,0 +1,127 @@
+var expect = require('chai').expect;
+var plugin = require('./hadoopSecureModeEnabled');
+
+const clusters = [
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-1',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+            {
+                state: 'CREATING',
+                stateStartTime: '2022-10-31T19:49:56.933052Z'
+            }
+        ],
+        config: {
+            securityConfig: {
+                kerberosConfig: {enableKerberos: true}
+            }
+        }
+    },
+    {
+        projectId: 'testproj',
+        clusterName: 'cluster-2',
+        status: { state: 'RUNNING', stateStartTime: '2022-10-31T19:51:22.817294Z' },
+        statusHistory: [
+          {
+            state: 'CREATING',
+            stateStartTime: '2022-10-31T19:49:56.933052Z'
+          }
+        ],
+        labels: {}
+    },
+];
+
+const createCache = (err, data) => {
+    return {
+        clusters: {
+            dataproc: {
+                list: {
+                     'us-central1': {
+                            err: err,
+                            data: data
+                    }
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('hadoopSecureModeEnabled', function () {
+    describe('run', function () {
+        it('should give unknown result if a cluster error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Dataproc clusters');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no clusters are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Dataproc clusters found');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if hadoop secure mode is enabled for the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Hadoop Secure mode is enabled');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if hadoop secure mode is not enabled for the cluster', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Hadoop Secure mode is not enabled');
+                expect(results[0].region).to.equal('us-central1');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [clusters[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/dns/dnsZoneLabelsAdded.js
+++ b/plugins/google/dns/dnsZoneLabelsAdded.js
@@ -1,0 +1,66 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'DNS Zone Labels Added',
+    category: 'DNS',
+    domain: 'Content Delivery',
+    description: 'Ensure Cloud DNS zones have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/dns/docs/zones',
+    recommended_action: 'Ensure labels are added for all managed zones in the cloud DNS service.',
+    apis: ['managedZones:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        let projects = helpers.addSource(cache, source,
+            ['projects','get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, (projects) ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        async.each(regions.managedZones, function(region, rcb){
+            let managedZones = helpers.addSource(cache, source,
+                ['managedZones', 'list', region]);
+
+            if (!managedZones) return rcb();
+
+            if (managedZones.err || !managedZones.data) {
+                helpers.addResult(results, 3, 'Unable to query DNS managed zones: ' + helpers.addError(managedZones), region, null, null, managedZones.err);
+                return rcb();
+            }
+
+            if (!managedZones.data.length) {
+                helpers.addResult(results, 0, 'No DNS managed zones found', region);
+                return rcb();
+            }
+
+            managedZones.data.forEach(managedZone => {
+                let resource = helpers.createResourceName('zones', managedZone.name, project);
+           
+                if (managedZone.labels &&
+                    Object.keys(managedZone.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(managedZone.labels).length} labels found for DNS managed zone`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'DNS managed zone does not have any labels', region, resource);
+                }
+
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/dns/dnsZoneLabelsAdded.spec.js
+++ b/plugins/google/dns/dnsZoneLabelsAdded.spec.js
@@ -1,0 +1,124 @@
+var expect = require('chai').expect;
+var plugin = require('./dnsZoneLabelsAdded');
+
+const createCache = (err, data) => {
+    return {
+        managedZones: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' }]
+                }
+            }
+        }
+    }
+};
+
+describe('dnsZoneLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a managed zone error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query DNS managed zones');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if no managed zone records are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No DNS managed zones found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if the managed zone has labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for DNS managed zone');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [
+                    {
+                        "name": "giotestdnszone1",
+                        "dnsName": "cloudsploit.com.",
+                        "description": "",
+                        "id": "4534388710135378441",
+                        "nameServers": [
+                            "ns-cloud-e1.googledomains.com.",
+                            "ns-cloud-e2.googledomains.com.",
+                            "ns-cloud-e3.googledomains.com.",
+                            "ns-cloud-e4.googledomains.com."
+                        ],
+                        "creationTime": "2019-10-03T21:11:18.894Z",
+                        "labels": {"test": "test"},
+                        "visibility": "public",
+                        "kind": "dns#managedZone"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if the managed zone does not have labels added', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [
+                    {
+                        "name": "giotestdnszone1",
+                        "dnsName": "cloudsploit.com.",
+                        "description": "",
+                        "id": "4534388710135378441",
+                        "nameServers": [
+                            "ns-cloud-e1.googledomains.com.",
+                            "ns-cloud-e2.googledomains.com.",
+                            "ns-cloud-e3.googledomains.com.",
+                            "ns-cloud-e4.googledomains.com."
+                        ],
+                        "creationTime": "2019-10-03T21:11:18.894Z",
+                        "visibility": "public",
+                        "kind": "dns#managedZone"
+                    }
+                ]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+});

--- a/plugins/google/kubernetes/aliasIpRangesEnabled.js
+++ b/plugins/google/kubernetes/aliasIpRangesEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Alias IP ranges allow users to assign ranges of internal IP addresses as alias to a network interface.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/',
     recommended_action: 'Ensure that Kubernetes clusters have alias IP ranges enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/aliasIpRangesEnabled.spec.js
+++ b/plugins/google/kubernetes/aliasIpRangesEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./aliasIpRangesEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/autoNodeRepairEnabled.js
+++ b/plugins/google/kubernetes/autoNodeRepairEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'When automatic repair on nodes is enabled, the Kubernetes engine performs health checks on all nodes, automatically repairing nodes that fail health checks. This ensures that the Kubernetes environment stays optimal.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair',
     recommended_action: 'Ensure that automatic node repair is enabled on all node pools in Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/autoNodeRepairEnabled.spec.js
+++ b/plugins/google/kubernetes/autoNodeRepairEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./autoNodeRepairEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/autoNodeUpgradesEnabled.js
+++ b/plugins/google/kubernetes/autoNodeUpgradesEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Enabling automatic upgrades on nodes ensures that each node stays current with the latest version of the master branch, also ensuring that the latest security patches are installed to provide the most secure environment.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades',
     recommended_action: 'Ensure that automatic node upgrades are enabled on all node pools in Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/autoNodeUpgradesEnabled.spec.js
+++ b/plugins/google/kubernetes/autoNodeUpgradesEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./autoNodeUpgradesEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/basicAuthenticationDisabled.js
+++ b/plugins/google/kubernetes/basicAuthenticationDisabled.js
@@ -10,7 +10,7 @@ module.exports = {
         'the recommended method to authenticate into the Kubernetes API server.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster',
     recommended_action: 'Disable basic authentication on all clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -28,9 +28,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/basicAuthenticationDisabled.spec.js
+++ b/plugins/google/kubernetes/basicAuthenticationDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./basicAuthenticationDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterEncryption.js
+++ b/plugins/google/kubernetes/clusterEncryption.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Application-layer secrets encryption adds additional security layer to sensitive data such as Kubernetes secrets stored in etcd.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets',
     recommended_action: 'Ensure that all GKE clusters have the desired application-layer secrets encryption level.',
-    apis: ['clusters:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['clusters:kubernetes:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         kubernetes_cluster_encryption_level: {
             name: 'Kubernetes Cluster Encryption Protection Level',
@@ -54,9 +54,9 @@ module.exports = {
                 });
             },
             function(cb) {
-                async.each(regions.clusters, function(region, rcb) {
+                async.each(regions.clusters.kubernetes, function(region, rcb) {
                     let clusters = helpers.addSource(cache, source,
-                        ['clusters', 'list', region]);
+                        ['clusters', 'kubernetes', 'list', region]);
 
                     if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterEncryption.spec.js
+++ b/plugins/google/kubernetes/clusterEncryption.spec.js
@@ -66,10 +66,12 @@ const clusters = [
 const createCache = (clustersList, clusterError, keysList, keysErr) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: clusterError,
-                    data: clustersList
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: clusterError,
+                        data: clustersList
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterLabelsAdded.js
+++ b/plugins/google/kubernetes/clusterLabelsAdded.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to add labels to Kubernetes clusters to apply specific security settings and auto configure objects at creation.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels',
     recommended_action: 'Ensure labels are added to Kubernetes clusters',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterLabelsAdded.spec.js
+++ b/plugins/google/kubernetes/clusterLabelsAdded.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./clusterLabelsAdded');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/clusterLeastPrivilege.js
+++ b/plugins/google/kubernetes/clusterLeastPrivilege.js
@@ -10,7 +10,7 @@ module.exports = {
         'Kubernetes default service account should be limited to minimal access scopes necessary to operate the clusters.',
     link: 'https://cloud.google.com/compute/docs/access/service-accounts',
     recommended_action: 'Ensure that all Kubernetes clusters are created with minimal access scope.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -28,10 +28,10 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
 
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/clusterLeastPrivilege.spec.js
+++ b/plugins/google/kubernetes/clusterLeastPrivilege.spec.js
@@ -4,9 +4,11 @@ var plugin = require('./clusterLeastPrivilege');
 const createCache = (clusterData) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    data: clusterData
+            kubernetes: {
+                list: {
+                    'global': {
+                        data: clusterData
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/cosImageEnabled.js
+++ b/plugins/google/kubernetes/cosImageEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Container-Optimized OS is optimized to enhance node security. It is backed by a team at Google that can quickly patch it.',
     link: 'https://cloud.google.com/container-optimized-os/',
     recommended_action: 'Enable Container-Optimized OS on all Kubernetes cluster nodes',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/cosImageEnabled.spec.js
+++ b/plugins/google/kubernetes/cosImageEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./cosImageEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/defaultServiceAccount.js
+++ b/plugins/google/kubernetes/defaultServiceAccount.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes cluster nodes should use customized service accounts that have minimal privileges to run. This reduces the attack surface in the case of a malicious attack on the cluster.',
     link: 'https://cloud.google.com/container-optimized-os/',
     recommended_action: 'Ensure that no Kubernetes cluster nodes are using the default service account',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/defaultServiceAccount.spec.js
+++ b/plugins/google/kubernetes/defaultServiceAccount.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./defaultServiceAccount');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/integrityMonitoringEnabled.js
+++ b/plugins/google/kubernetes/integrityMonitoringEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Integrity Monitoring feature automatically monitors the integrity of your cluster nodes.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#integrity_monitoring',
     recommended_action: 'Enable Integrity Monitoring feature for your cluster nodes',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/integrityMonitoringEnabled.spec.js
+++ b/plugins/google/kubernetes/integrityMonitoringEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./integrityMonitoringEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/kubernetesAlphaDisabled.js
+++ b/plugins/google/kubernetes/kubernetesAlphaDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to not use Alpha clusters as they expire after thirty days and do not receive security updates.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/concepts/alpha-clusters',
     recommended_action: '1. Create a new cluster with the alpha feature disabled. 2. Migrate all required cluster data from the cluster with alpha to this newly created cluster. 3.Delete the engine cluster with alpha enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/kubernetesAlphaDisabled.spec.js
+++ b/plugins/google/kubernetes/kubernetesAlphaDisabled.spec.js
@@ -4,10 +4,12 @@ var plugin = require('./kubernetesAlphaDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/legacyAuthorizationDisabled.js
+++ b/plugins/google/kubernetes/legacyAuthorizationDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'The legacy authorizer in Kubernetes grants broad, statically defined permissions.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster',
     recommended_action: 'Disable legacy authorization on all clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/legacyAuthorizationDisabled.spec.js
+++ b/plugins/google/kubernetes/legacyAuthorizationDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./legacyAuthorizationDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/loggingEnabled.js
+++ b/plugins/google/kubernetes/loggingEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'This setting should be enabled to ensure Kubernetes control plane logs are properly recorded.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/legacy-stackdriver/logging',
     recommended_action: 'Ensure that logging is enabled on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
     compliance: {
         hipaa: 'HIPAA requires the logging of all activity ' +
             'including access and all actions taken.'
@@ -31,9 +31,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/loggingEnabled.spec.js
+++ b/plugins/google/kubernetes/loggingEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./loggingEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/masterAuthorizedNetwork.js
+++ b/plugins/google/kubernetes/masterAuthorizedNetwork.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Authorized networks are a way of specifying a restricted range of IP addresses that are permitted to access your container clusters Kubernetes master endpoint.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/authorized-networks',
     recommended_action: 'Enable master authorized networks on all clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/masterAuthorizedNetwork.spec.js
+++ b/plugins/google/kubernetes/masterAuthorizedNetwork.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./masterAuthorizedNetwork');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/monitoringEnabled.js
+++ b/plugins/google/kubernetes/monitoringEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes supports monitoring through Stackdriver.',
     link: 'https://cloud.google.com/monitoring/kubernetes-engine/',
     recommended_action: 'Ensure monitoring is enabled on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/monitoringEnabled.spec.js
+++ b/plugins/google/kubernetes/monitoringEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./monitoringEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/networkPolicyEnabled.js
+++ b/plugins/google/kubernetes/networkPolicyEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes network policy creates isolation between cluster pods, this creates a more secure environment with only specified connections allowed.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy',
     recommended_action: 'Enable network policy on all Kubernetes clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/networkPolicyEnabled.spec.js
+++ b/plugins/google/kubernetes/networkPolicyEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./networkPolicyEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/nodeEncryption.js
+++ b/plugins/google/kubernetes/nodeEncryption.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Using Customer Managed Keys (CMKs) gives you better control over the encryption/decryption process of your cluster nodes.',
     link: 'https://cloud.google.com/security/encryption/default-encryption',
     recommended_action: 'Ensure that all node pools in GKE clusters have the desired encryption level.',
-    apis: ['clusters:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
+    apis: ['clusters:kubernetes:list', 'projects:get', 'keyRings:list', 'cryptoKeys:list'],
     settings: {
         kubernetes_node_encryption_level: {
             name: 'Kubernetes Node Encryption Protection Level',
@@ -56,9 +56,9 @@ module.exports = {
                 });
             },
             function(cb) {
-                async.each(regions.clusters, function(region, rcb) {
+                async.each(regions.clusters.kubernetes, function(region, rcb) {
                     let clusters = helpers.addSource(cache, source,
-                        ['clusters', 'list', region]);
+                        ['clusters', 'kubernetes', 'list', region]);
 
                     if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/nodeEncryption.spec.js
+++ b/plugins/google/kubernetes/nodeEncryption.spec.js
@@ -75,10 +75,12 @@ const clusters = [
 const createCache = (clustersList, clusterError, keysList, keysErr) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: clusterError,
-                    data: clustersList
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: clusterError,
+                        data: clustersList
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/podSecurityPolicyEnabled.js
+++ b/plugins/google/kubernetes/podSecurityPolicyEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes pod security policy is a resource that controls security sensitive aspects of the pod configuration.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies',
     recommended_action: 'Ensure that all Kubernetes clusters have pod security policy enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/podSecurityPolicyEnabled.spec.js
+++ b/plugins/google/kubernetes/podSecurityPolicyEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./podSecurityPolicyEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/privateClusterEnabled.js
+++ b/plugins/google/kubernetes/privateClusterEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Kubernetes private clusters only have internal ip ranges, which ensures that their workloads are isolated from the public internet.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters',
     recommended_action: 'Ensure that all Kubernetes clusters have private cluster enabled.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, (region, rcb) => {
+        async.each(regions.clusters.kubernetes, (region, rcb) => {
             var clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/privateClusterEnabled.spec.js
+++ b/plugins/google/kubernetes/privateClusterEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./privateClusterEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/privateEndpoint.js
+++ b/plugins/google/kubernetes/privateEndpoint.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'kubernetes private endpoints can be used to route all traffic between the Kubernetes worker and control plane nodes over a private VPC endpoint rather than across the public internet.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters',
     recommended_action: 'Enable the private endpoint setting for all GKE clusters when creating the cluster.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/privateEndpoint.spec.js
+++ b/plugins/google/kubernetes/privateEndpoint.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./privateEndpoint');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/secureBootEnabled.js
+++ b/plugins/google/kubernetes/secureBootEnabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Secure Boot feature protects your cluster nodes from malware and makes sure the system runs only authentic software.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot',
     recommended_action: 'Ensure that Secure Boot feature is enabled for all node pools in your GKE clusters.',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/secureBootEnabled.spec.js
+++ b/plugins/google/kubernetes/secureBootEnabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./secureBootEnabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/shieldedNodes.js
+++ b/plugins/google/kubernetes/shieldedNodes.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'Shielded GKE nodes give strong cryptographic identity. This prevents attackers from being able to impersonate a node in your GKE cluster even if the attacker can extract the node credentials.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes',
     recommended_action: 'Ensure that shielded nodes setting is enabled in your GKE cluster',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
    
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/shieldedNodes.spec.js
+++ b/plugins/google/kubernetes/shieldedNodes.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./shieldedNodes');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/kubernetes/webDashboardDisabled.js
+++ b/plugins/google/kubernetes/webDashboardDisabled.js
@@ -9,7 +9,7 @@ module.exports = {
     more_info: 'It is recommended to disable the web dashboard because it is backed by a highly privileged service account.',
     link: 'https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards',
     recommended_action: 'Ensure that no Kubernetes clusters have the web dashboard enabled',
-    apis: ['clusters:list', 'projects:get'],
+    apis: ['clusters:kubernetes:list', 'projects:get'],
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -27,9 +27,9 @@ module.exports = {
 
         var project = projects.data[0].name;
 
-        async.each(regions.clusters, function(region, rcb){
+        async.each(regions.clusters.kubernetes, function(region, rcb){
             let clusters = helpers.addSource(cache, source,
-                ['clusters', 'list', region]);
+                ['clusters', 'kubernetes', 'list', region]);
 
             if (!clusters) return rcb();
 

--- a/plugins/google/kubernetes/webDashboardDisabled.spec.js
+++ b/plugins/google/kubernetes/webDashboardDisabled.spec.js
@@ -5,10 +5,12 @@ var plugin = require('./webDashboardDisabled');
 const createCache = (err, data) => {
     return {
         clusters: {
-            list: {
-                'global': {
-                    err: err,
-                    data: data
+            kubernetes: {
+                list: {
+                    'global': {
+                        err: err,
+                        data: data
+                    }
                 }
             }
         },

--- a/plugins/google/pubsub/topicLabelsAdded.js
+++ b/plugins/google/pubsub/topicLabelsAdded.js
@@ -1,0 +1,52 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Topic Labels Added',
+    category: 'Pub/Sub',
+    domain: 'Application Integration',
+    description: 'Ensure that all Pub/Sub topics have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/pubsub/docs/labels',
+    recommended_action: 'Ensure labels are added to all Pub/Sub topics.',
+    apis: ['topics:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.topics, function(region, rcb){
+            let topics = helpers.addSource(cache, source,
+                ['topics', 'list', region]);
+
+            if (!topics) return rcb();
+
+            if (topics.err || !topics.data) {
+                helpers.addResult(results, 3, 'Unable to query Pub/Sub topics', region, null, null, topics.err);
+                return rcb();
+            }
+
+            if (!topics.data.length) {
+                helpers.addResult(results, 0, 'No Pub/Sub topics found', region);
+                return rcb();
+            }
+
+            topics.data.forEach(topic => {
+                if (topic.labels &&
+                    Object.keys(topic.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(topic.labels).length} labels found for Pub/Sub topic`, region, topic.name);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Pub/Sub topic does not have any labels', region, topic.name);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/pubsub/topicLabelsAdded.spec.js
+++ b/plugins/google/pubsub/topicLabelsAdded.spec.js
@@ -1,0 +1,97 @@
+var expect = require('chai').expect;
+var plugin = require('./topicLabelsAdded');
+
+const topics = [
+    {
+        name: 'projects/testproj/topics/topic-1',
+        labels: { label1: 'topic' },
+    },
+    {
+        name: 'projects/testproj/topics/topic-2'
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        topics: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        }
+    }
+};
+
+describe('topicLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a topic error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Pub/Sub topics');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no topics are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Pub/Sub topics found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the topic', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for Pub/Sub topic');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [topics[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the topic', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Pub/Sub topic does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [topics[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})

--- a/plugins/google/sql/mysqlLatestVersion.js
+++ b/plugins/google/sql/mysqlLatestVersion.js
@@ -29,7 +29,7 @@ module.exports = {
 
         const latestMySQLVersion = 8.0;
 
-        async.each(regions.sql, function(region, rcb){
+        async.each(regions.instances.sql, function(region, rcb){
             let sqlInstances = helpers.addSource(
                 cache, source, ['instances', 'sql', 'list', region]);
 

--- a/plugins/google/storage/bucketLabelsAdded.js
+++ b/plugins/google/storage/bucketLabelsAdded.js
@@ -1,0 +1,54 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Bucket Labels Added',
+    category: 'Storage',
+    domain: 'Storage',
+    description: 'Ensure that all Cloud Storage buckets have labels added.',
+    more_info: 'Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.Labels are a lightweight way to group resources together that are related to or associated with each other. It is a best practice to label cloud resources to better organize and gain visibility into their usage.',
+    link: 'https://cloud.google.com/storage/docs/using-bucket-labels',
+    recommended_action: 'Ensure labels are added to all storage buckets.',
+    apis: ['buckets:list'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.buckets, function(region, rcb){
+            let buckets = helpers.addSource(cache, source,
+                ['buckets', 'list', region]);
+
+            if (!buckets) return rcb();
+
+            if (buckets.err || !buckets.data) {
+                helpers.addResult(results, 3, 'Unable to query storage buckets', region, null, null, buckets.err);
+                return rcb();
+            }
+
+            if (!buckets.data.length) {
+                helpers.addResult(results, 0, 'No storage buckets found', region);
+                return rcb();
+            }
+
+            buckets.data.forEach(bucket => {
+                let resource = helpers.createResourceName('b', bucket.name);
+
+                if (bucket.labels &&
+                    Object.keys(bucket.labels).length) {
+                    helpers.addResult(results, 0,
+                        `${Object.keys(bucket.labels).length} labels found for storage bucket`, region, resource);
+                } else {
+                    helpers.addResult(results, 2,
+                        'Storage bucket does not have any labels', region, resource);
+                }
+            });
+
+            rcb();
+        }, function(){
+            // Global checking goes here
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/storage/bucketLabelsAdded.spec.js
+++ b/plugins/google/storage/bucketLabelsAdded.spec.js
@@ -1,0 +1,103 @@
+var expect = require('chai').expect;
+var plugin = require('./bucketLabelsAdded');
+
+const buckets = [
+    {
+        kind: 'storage#bucket',
+        selfLink: 'https://www.googleapis.com/storage/v1/b/testproj-bucket-1',
+        id: 'testproj-bucket-1',
+        name: 'testproj-bucket-1',
+        labels: { bucket: 'label' },
+    },
+    {
+        kind: 'storage#bucket',
+        selfLink: 'https://www.googleapis.com/storage/v1/b/testproj-bucket-2',
+        id: 'testproj-bucket-2',
+        name: 'testproj-bucket-2'    
+    }
+];
+
+const createCache = (err, data) => {
+    return {
+        buckets: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        }
+    }
+};
+
+describe('bucketLabelsAdded', function () {
+    describe('run', function () {
+        it('should give unknown result if a bucket error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query storage buckets');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no buckets are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No storage buckets found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [],
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if labels have been added to the bucket', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('labels found for storage bucket');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [buckets[0]]
+            );
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if no labels have been added to the bucket', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Storage bucket does not have any labels');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+
+            const cache = createCache(
+                null,
+                [buckets[1]]
+            );
+
+            plugin.run(cache, {}, callback);
+        })
+    })
+})


### PR DESCRIPTION
1 Bigquery rule
1 Bigtable rule
1 Cloud Function rule
4 Compute rules
3 Dataproc rules
1 DNS rule
1 Kubernetes rule
1 Pub/Sub rule
1 Storage rule

Updated collector.js with new collectors
Updated export.js with the new rules
Updated regions.js with the scopes for the new collectors Change API call for Kubernetes collector and related rules Minor correction in 1 SQL rule